### PR TITLE
standardization: Create a python package of zircbot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,4 @@
+zircbot
+=======
+
+This is a Readme

--- a/config-sample.yml
+++ b/config-sample.yml
@@ -10,6 +10,9 @@ password: ''
 method: connect
 # 0MQ Endpoint
 endpoint: tcp://localhost:7777
-# association between trello board and irc channels
+# association between applications and irc channels
 trello:
   <BOARD_SHORT_ID>: ['#mychan']
+  <BOARD_SHORT_ID_2>: ['#mychan2']
+sensu:
+  <SENSU_DC_NAME>: ['#mychan-admin']

--- a/data/sensu_create.json
+++ b/data/sensu_create.json
@@ -1,0 +1,55 @@
+{
+  "id": "2d344dc8-5f3b-457a-acb9-3674a21d75f7",
+  "dcid": "mydc",
+  "client": {
+    "name": "monitoring",
+    "address": "127.0.0.1",
+    "subscriptions": [
+      "base"
+    ],
+    "version": "0.21.0",
+    "timestamp": 1453389843
+  },
+  "check": {
+    "command": "check-ports.rb -h 0.0.0.0 -p 80 -t 30",
+    "interval": 10,
+    "standalone": true,
+    "handlers": [
+      "irc",
+      "file"
+    ],
+    "name": "uchiwa",
+    "issued": 1453389848,
+    "executed": 1453389848,
+    "duration": 0.145,
+    "output": "CheckPort CRITICAL: Connection refused by 0.0.0.0:80\n",
+    "status": 2,
+    "history": [
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2"
+    ],
+    "total_state_change": 0
+  },
+  "occurrences": 22,
+  "action": "create",
+  "timestamp": 1453389849
+}

--- a/data/sensu_resolve.json
+++ b/data/sensu_resolve.json
@@ -1,0 +1,55 @@
+{
+  "id": "9f4c5e36-e08b-4b04-99a7-2c5806a8177c",
+  "dcid": "mydc",
+  "client": {
+    "name": "monitoring",
+    "address": "127.0.0.1",
+    "subscriptions": [
+      "base"
+    ],
+    "version": "0.21.0",
+    "timestamp": 1453302198
+  },
+  "check": {
+    "command": "check-ports.rb -h 0.0.0.0 -p 80 -t 30",
+    "interval": 10,
+    "standalone": true,
+    "handlers": [
+      "irc",
+      "file"
+    ],
+    "name": "uchiwa",
+    "issued": 1453302212,
+    "executed": 1453302212,
+    "duration": 0.13,
+    "output": "CheckPort OK: All ports (80) are accessible for host 0.0.0.0\n",
+    "status": 0,
+    "history": [
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "2",
+      "0"
+    ],
+    "total_state_change": 6
+  },
+  "occurrences": 114,
+  "action": "resolve",
+  "timestamp": 1453302212
+}

--- a/data/trello.json
+++ b/data/trello.json
@@ -1,0 +1,87 @@
+{
+  "trello": {
+    "action": {
+      "type": "updateCard",
+      "idMemberCreator": "5137406a93c18ca34e006232",
+      "memberCreator": {
+        "username": "fredericlepied",
+        "fullName": "Frederic Lepied",
+        "initials": "FL",
+        "id": "5137406a93c18ca34e006232",
+        "avatarHash": "3844765cb385eb13674402d3f33aadc4"
+      },
+      "date": "2015-12-14T18:58:52.564Z",
+      "data": {
+        "listBefore": {
+          "name": "In Progress",
+          "id": "5494215d5d161ca15c8ac4f2"
+        },
+        "old": {
+          "idList": "5494215d5d161ca15c8ac4f2"
+        },
+        "board": {
+          "id": "5494190f407d96f733efedca",
+          "name": "Test Board",
+          "shortLink": "I0obloif"
+        },
+        "card": {
+          "idShort": 25,
+          "id": "5497fb29a42aa12be882402c",
+          "name": "US5",
+          "idList": "5494192403321a4796389930",
+          "shortLink": "TldNlDYl"
+        },
+        "listAfter": {
+          "name": "To Do",
+          "id": "5494192403321a4796389930"
+        }
+      },
+      "id": "566f116cbad4979631602343"
+    },
+    "model": {
+      "descData": null,
+      "labelNames": {
+        "blue": "",
+        "pink": "",
+        "purple": "",
+        "sky": "",
+        "yellow": "",
+        "green": "",
+        "orange": "",
+        "black": "",
+        "red": "",
+        "lime": ""
+      },
+      "name": "Test Board",
+      "shortUrl": "https://trello.com/b/I0obloif",
+      "idOrganization": null,
+      "pinned": false,
+      "url": "https://trello.com/b/I0obloif/test-board",
+      "closed": false,
+      "prefs": {
+        "permissionLevel": "private",
+        "cardCovers": true,
+        "backgroundColor": "#0079BF",
+        "selfJoin": false,
+        "backgroundBrightness": "unknown",
+        "comments": "members",
+        "invitations": "members",
+        "canBePrivate": true,
+        "canInvite": true,
+        "backgroundImage": null,
+        "backgroundTile": false,
+        "background": "blue",
+        "canBeOrg": true,
+        "cardAging": "regular",
+        "backgroundImageScaled": null,
+        "calendarFeedEnabled": false,
+        "voting": "members",
+        "canBePublic": true
+      },
+      "id": "5494190f407d96f733efedca",
+      "desc": ""
+    }
+  }
+}
+
+

--- a/publish.py
+++ b/publish.py
@@ -24,6 +24,8 @@ configured IRC chans.
 from optparse import OptionParser
 import time
 
+import json
+
 from txzmq import ZmqEndpoint
 from txzmq import ZmqFactory
 from txzmq import ZmqPubConnection
@@ -35,7 +37,9 @@ def main():
     parser.add_option("-m", "--method", dest="method",
                       help="0MQ socket connection: bind|connect")
     parser.add_option("-e", "--endpoint", dest="endpoint", help="0MQ Endpoint")
-    parser.set_defaults(method="bind", endpoint="tcp://*:5555")
+    parser.add_option("-f", "--file", dest="file", help="JSON file to parse")
+    parser.add_option("-p", "--plugin", dest="plugin", help="zircbot plugin to use")
+    parser.set_defaults(method="bind", endpoint="tcp://*:7777", file='data/trello.json', plugin='trello')
 
     (options, args) = parser.parse_args()
 
@@ -45,9 +49,8 @@ def main():
     s = ZmqPubConnection(zf, e)
 
     def publish():
-        data = str(time.time())
-        print "publishing %r" % data
-        s.publish(data)
+        data = json.load(open(options.file, 'r'))
+        s.publish(json.dumps({options.plugin: data}))
         reactor.callLater(1, publish)
 
     publish()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,48 @@
+from setuptools import setup, find_packages
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='zircbot',
+    version='0.0.1',
+    description='An IRC bot that retrieve message from 0MQ',
+    long_description=long_description,
+
+    url='https://github.com/fredericlepied/zircbot',
+
+    author='Frederic Lepied',
+    author_email='flepied@redhat.com',
+
+    license='Apache v2.0',
+
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ],
+
+    keywords='irc bot 0mq',
+
+    packages=find_packages(exclude=['tests']),
+
+    install_requires=['txzmq', 'PyYAML'],
+
+    entry_points={
+        'console_scripts': [
+            'zircbot=zircbot:main',
+        ],
+    },
+)

--- a/tests/test_sensu_serialization.py
+++ b/tests/test_sensu_serialization.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# Author: Frederic Lepied <frederic.lepied@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import json
+import sys
+import unittest
+
+from twisted.python import log
+import zircbot
+
+
+log.startLogging(sys.stdout)
+
+
+def validate(obj, json_str, output):
+    result = zircbot.plugins.sensu.to_message(json.loads(json_str)['sensu'])
+    obj.assertEquals(result, output)
+
+
+class TestSensuSerialization(unittest.TestCase):
+
+    def test_action_resolve(self):
+        validate(self, ACTION_RESOLVE,
+                           '(monitoring) RESOLVE: uchiwa - CheckPort OK: All '
+                           'ports (80) are accessible for host 0.0.0.0')
+
+    def test_action_create(self):
+        validate(self, ACTION_CREATE,
+                           '(monitoring) ALERT: uchiwa - CheckPort CRITICAL: '
+                           'Connection refused by 0.0.0.0:80')
+
+ACTION_RESOLVE = '{ "sensu" : { "id": "9f4c5e36-e08b-4b04-99a7-2c5806a8177c", "dcid": "mydc", "client": { "name": "monitoring", "address": "127.0.0.1", "subscriptions": [ "base" ], "version": "0.21.0", "timestamp": 1453302198 }, "check": { "command": "check-ports.rb -h 0.0.0.0 -p 80 -t 30", "interval": 10, "standalone": true, "handlers": [ "irc", "file" ], "name": "uchiwa", "issued": 1453302212, "executed": 1453302212, "duration": 0.13, "output": "CheckPort OK: All ports (80) are accessible for host 0.0.0.0", "status": 0, "history": [ "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "0" ], "total_state_change": 6 }, "occurrences": 114, "action": "resolve", "timestamp": 1453302212 }}'
+
+ACTION_CREATE = '{ "sensu" : {"id": "2d344dc8-5f3b-457a-acb9-3674a21d75f7", "dcid": "mydc", "client": { "name": "monitoring", "address": "46.231.133.106", "subscriptions": [ "base" ], "version": "0.21.0", "timestamp": 1453389843 }, "check": { "command": "check-ports.rb -h 0.0.0.0 -p 80 -t 30", "interval": 10, "standalone": true, "handlers": [ "irc", "file" ], "name": "uchiwa", "issued": 1453389848, "executed": 1453389848, "duration": 0.145, "output": "CheckPort CRITICAL: Connection refused by 0.0.0.0:80", "status": 2, "history": [ "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2", "2" ], "total_state_change": 0 }, "occurrences": 22, "action": "create", "timestamp": 1453389849 }}'

--- a/tests/test_trello_serialization.py
+++ b/tests/test_trello_serialization.py
@@ -27,11 +27,11 @@ log.startLogging(sys.stdout)
 
 
 def validate(obj, json_str, output):
-    result = zircbot.trello_to_message(json.loads(json_str)['trello'])
+    result = zircbot.plugins.trello.to_message(json.loads(json_str)['trello'])
     obj.assertEquals(result, output)
 
 
-class TestZircbot(unittest.TestCase):
+class TestTrelloSerizalization(unittest.TestCase):
 
     def test_move_card(self):
         validate(self, CARD_MOVED_JSON,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps=nose
+commands=nosetests

--- a/zircbot/plugins/sensu.py
+++ b/zircbot/plugins/sensu.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from twisted.python import log
+
+def get_channels(data):
+    '''Return the list of channels the zircbot should connect to
+       notify sensu events'''
+
+    return sum(data.values(), [])
+
+def get_information(ctx, data):
+
+    message = to_message(data)
+    channels = ctx[data['dcid']]
+
+    return message, channels
+
+def to_message(data):
+    try:
+        return   '(%s) %s: %s - %s' % (get_client_name(data), get_action(data).upper(), get_check_name(data), get_check_output(data).rstrip())
+    except:
+        log.msg('error decoding data %s:' % data)
+        log.msg(traceback.format_exc())
+    return None
+
+def get_client_name(data):
+    return data['client']['name']
+
+def get_action(data):
+    action = data['action']
+    if data['action'] == 'create':
+        action = 'alert'
+    return action
+
+def get_check_name(data):
+    return data['check']['name']
+
+def get_check_output(data):
+    return data['check']['output']

--- a/zircbot/plugins/trello.py
+++ b/zircbot/plugins/trello.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from twisted.python import log
+
+
+_CARD_ASSOC = {
+    'addMemberToCard': 'added to',
+    'removeMemberFromCard': 'removed from',
+    'createCard': 'created',
+    'deleteCard': 'deleted',
+    'commentCard': 'commented on',
+    'updateCard': 'updated',
+    'addAttachmentToCard': 'added an attachment to',
+    'addChecklistToCard': 'not used',
+    'createCheckItem': 'not used',
+    'updateCheckItemStateOnCard': 'not used',
+    'updateComment': 'udpated a comment on',
+}
+
+def get_channels(data):
+    '''Return the list of channels the zircbot should connect to
+       notify trello events'''
+
+    return sum(data.values(), [])
+
+
+def get_information(ctx, data):
+    data = data['trello']
+
+    message = to_message(data)
+
+    board_name = data['action']['data']['board']['shortLink']
+    channels = ctx[board_name]
+
+    return message, channels
+
+def to_message(data):
+    board_assoc = {
+        'addMemberToBoard': 'added to',
+        'removeMemberFromBoard': 'removed from',
+    }
+    try:
+        if data['action']['type'] in _CARD_ASSOC:
+            if 'member' in data['action']:
+                member = 'member'
+            else:
+                member = 'memberCreator'
+            return '%s %s the card "%s": %s' % \
+                (data['action'][member]['fullName'],
+                 get_action(data['action']),
+                 get_card_name(data['action']['data']['card']),
+                 get_url(data['action']['data']))
+        elif data['action']['type'] in board_assoc:
+            return '%s %s the board: %s' % \
+                (data['action']['member']['fullName'],
+                 board_assoc[data['action']['type']],
+                 data['model']['shortUrl'])
+        else:
+            log.msg('unsupported data %s:' % data)
+    except:
+        log.msg('error decoding data %s:' % data)
+        log.msg(traceback.format_exc())
+    return None
+
+def get_card_name(card_data):
+    try:
+        return card_data['name']
+    except KeyError:
+        return card_data['idShort']
+
+def get_url(data):
+    if 'attachment' in data and 'url' in data['attachment']:
+        return data['attachment']['url']
+    else:
+        return 'https://trello.com/c/' + data['card']['shortLink']
+
+def get_action(data):
+    if data['type'] == 'updateCard':
+        if 'listAfter' in data['data']:
+            return('moved to the list "%s"' %
+                   data['data']['listAfter']['name'])
+        if 'closed' in data['data']['card'] and \
+           data['data']['card']['closed'] is True:
+            return('archived')
+    elif data['type'] == 'addChecklistToCard':
+        return('added the list "%s" to' % data['data']['checklist']['name'])
+    elif data['type'] == 'createCheckItem':
+        return('added "%s" to the list "%s" of' %
+               (data['data']['checkItem']['name'],
+                data['data']['checklist']['name']))
+    elif data['type'] == 'updateCheckItemStateOnCard':
+        return('%schecked "%s" to the list "%s" of' %
+               ('' if data['data']['checkItem']['state'] == 'complete'
+                else 'un',
+                data['data']['checkItem']['name'],
+                data['data']['checklist']['name']))
+    return _CARD_ASSOC[data['type']]


### PR DESCRIPTION
Currently zircbot is a python script. It does one thing and does it
well, transform Trello event into IRC message.

We can imagine that Trello is just a backend and that we might want to
implement others with the notion of plugins/drivers.

In order to add more feature to this module applying some python
packaging rules from the beginning might be a good idea
